### PR TITLE
Move Youtube API requests to client, add polling to sync chat

### DIFF
--- a/lib/google.js
+++ b/lib/google.js
@@ -1,0 +1,21 @@
+const YOUTUBE_API = 'https://www.googleapis.com/youtube/v3';
+
+export function liveChatMessagesList(token, params) {
+  const url = new URL(`${YOUTUBE_API}/liveChat/messages`);
+  url.search = new URLSearchParams(params).toString();
+  return fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    }
+  })
+}
+
+export function liveBroadcastList(token, params) {
+  const url = new URL(`${YOUTUBE_API}/liveBroadcasts`);
+  url.search = new URLSearchParams(params).toString();
+  return fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "date-fns": "^2.21.1",
-    "googleapis": "^72.0.0",
     "gray-matter": "^4.0.2",
     "next": "^10.0.0",
     "next-auth": "^3.16.1",


### PR DESCRIPTION
- Remove Google Node API Client because it only runs in Node. Need something that runs on both client + server
- Add my own basic API logic using vanilla fetch
- Move SSR logic to client - no need for this to be server-side rendered
- Add basic polling mechanism which reads the previous response's `pollingIntervalMillis` and waits that amount of time before making another request.


https://user-images.githubusercontent.com/4837696/116327726-6caa5500-a795-11eb-8aa2-09af1491ce6a.mp4

